### PR TITLE
Added Capability to support TabBarController and NavigationController

### DIFF
--- a/ElongationPreview.xcodeproj/project.pbxproj
+++ b/ElongationPreview.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		078089231F4E201500892B33 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 078089201F4E201500892B33 /* InitialViewController.swift */; };
+		078089241F4E201500892B33 /* NCStoryBoard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 078089211F4E201500892B33 /* NCStoryBoard.storyboard */; };
+		078089251F4E201500892B33 /* TabBStoryBoard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 078089221F4E201500892B33 /* TabBStoryBoard.storyboard */; };
 		9D0CDAD61E4B5A3000BB945B /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0CDAD51E4B5A3000BB945B /* UIEdgeInsets.swift */; };
 		9D252C221E57286E00B68833 /* Roboto-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9D252C211E57286E00B68833 /* Roboto-Bold.ttf */; };
 		9D252C241E575B9B00B68833 /* SwipableTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D252C231E575B9B00B68833 /* SwipableTableViewController.swift */; };
@@ -72,6 +75,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		078089201F4E201500892B33 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
+		078089211F4E201500892B33 /* NCStoryBoard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NCStoryBoard.storyboard; sourceTree = "<group>"; };
+		078089221F4E201500892B33 /* TabBStoryBoard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = TabBStoryBoard.storyboard; sourceTree = "<group>"; };
 		9D0CDAD51E4B5A3000BB945B /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		9D252C211E57286E00B68833 /* Roboto-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Roboto-Bold.ttf"; sourceTree = "<group>"; };
 		9D252C231E575B9B00B68833 /* SwipableTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipableTableViewController.swift; sourceTree = "<group>"; };
@@ -261,6 +267,9 @@
 		9DE4FAD31E4B1A15008502A3 /* ElongationPreviewDemo */ = {
 			isa = PBXGroup;
 			children = (
+				078089201F4E201500892B33 /* InitialViewController.swift */,
+				078089211F4E201500892B33 /* NCStoryBoard.storyboard */,
+				078089221F4E201500892B33 /* TabBStoryBoard.storyboard */,
 				9DE4FAD41E4B1A15008502A3 /* AppDelegate.swift */,
 				9DE4FAD61E4B1A15008502A3 /* ViewController.swift */,
 				9D8937301E539DDD00FDC29D /* DetailViewController.swift */,
@@ -441,10 +450,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				9D252C221E57286E00B68833 /* Roboto-Bold.ttf in Resources */,
+				078089241F4E201500892B33 /* NCStoryBoard.storyboard in Resources */,
 				9DF1BC5E1E5B5A7700AFB21C /* DemoElongationCell.xib in Resources */,
 				9DF1BC601E5B5A7700AFB21C /* GridViewCell.xib in Resources */,
 				9D69D1321E4EF2A900D38C59 /* Roboto-Regular.ttf in Resources */,
 				9D69D1311E4EF2A900D38C59 /* Roboto-Medium.ttf in Resources */,
+				078089251F4E201500892B33 /* TabBStoryBoard.storyboard in Resources */,
 				9DE4FADF1E4B1A15008502A3 /* LaunchScreen.storyboard in Resources */,
 				9DE4FADC1E4B1A15008502A3 /* Assets.xcassets in Resources */,
 				9DE4FADA1E4B1A15008502A3 /* Main.storyboard in Resources */,
@@ -487,6 +498,7 @@
 				9DE4FAD71E4B1A15008502A3 /* ViewController.swift in Sources */,
 				9DE4FAD51E4B1A15008502A3 /* AppDelegate.swift in Sources */,
 				9D69D13B1E4EF31C00D38C59 /* UIFont.swift in Sources */,
+				078089231F4E201500892B33 /* InitialViewController.swift in Sources */,
 				9D44D0F61E4C3A5E00F6A335 /* Villa.swift in Sources */,
 				9D44D0F31E4C301000F6A335 /* LoremSwiftum.swift in Sources */,
 				9D8937311E539DDD00FDC29D /* DetailViewController.swift in Sources */,

--- a/ElongationPreview/Source/ElongationTransition.swift
+++ b/ElongationPreview/Source/ElongationTransition.swift
@@ -19,42 +19,24 @@ public class ElongationTransition: NSObject {
   }
   
   // MARK: Properties
-  fileprivate var presenting = true
+  var presenting :Bool = false
+
+  fileprivate var elongationConfig: ElongationConfig { return ElongationConfig.shared }
+
+  
+  /// used whenever you need to get some settings (Configured at the AppDelegate) about the framework.
+  lazy var animationDuration : TimeInterval = {
+        [unowned self] in
+        return self.presenting ? self.elongationConfig.detailPresetingDuration : self.elongationConfig.detailDismissingDuration
+  }()
+   
+    
+  /// an instance of the ElongationConfig Singleton.
   fileprivate var appearance: ElongationConfig { return ElongationConfig.shared }
   
   fileprivate let additionalOffsetY: CGFloat = 30
   
-  fileprivate var rootKey: UITransitionContextViewControllerKey {
-    return presenting ? .from : .to
-  }
-  fileprivate var detailKey: UITransitionContextViewControllerKey {
-    return presenting ? .to : .from
-  }
-  fileprivate var rootViewKey: UITransitionContextViewKey {
-    return presenting ? .from : .to
-  }
-  fileprivate var detailViewKey: UITransitionContextViewKey {
-    return presenting ? .to : .from
-  }
-  
-  fileprivate func root(from context: UIViewControllerContextTransitioning) -> ElongationViewController {
-    let viewController = context.viewController(forKey: rootKey)
-    
-    if let navi = viewController as? UINavigationController {
-      for case let elongationViewController as ElongationViewController in navi.viewControllers {
-        return elongationViewController
-      }
-    } else if let elongationViewController = viewController as? ElongationViewController {
-      return elongationViewController
-    }
-    
-    fatalError("Can't get `ElongationViewController` from UINavigationController nor from context's viewController itself.")
-  }
-  
-  fileprivate func detail(from context: UIViewControllerContextTransitioning) -> ElongationDetailViewController {
-    return context.viewController(forKey: detailKey) as? ElongationDetailViewController ?? ElongationDetailViewController(nibName: nil, bundle: nil)
-  }
-  
+
 }
 
 // MARK: - Transition Protocol Implementation
@@ -67,6 +49,11 @@ extension ElongationTransition: UIViewControllerAnimatedTransitioning {
   
   /// :nodoc:
   open func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+    let fromVC        = transitionContext.viewController(forKey: .from)!
+
+    // presenting is true when the animation comes from an ElongationDetailViewController instance. I preffer to leave the variable as the original repo even now is not much intuitive the description.
+    presenting = !(fromVC .isKind(of: ElongationDetailViewController.self))
+
     presenting ? present(using: transitionContext) : dismiss(using: transitionContext)
   }
   
@@ -76,40 +63,56 @@ extension ElongationTransition: UIViewControllerAnimatedTransitioning {
 extension ElongationTransition {
   
   fileprivate func present(using context: UIViewControllerContextTransitioning) {
-    let duration = transitionDuration(using: context)
-    let containerView = context.containerView
-    let root = self.root(from: context) // ElongationViewController
-    let detail = self.detail(from: context) // ElongationDetailViewController
-    let rootView = context.view(forKey: rootViewKey)
-    let detailView = context.view(forKey: detailViewKey)
     
-    let detailViewFinalFrame = context.finalFrame(for: detail) // Final frame for presenting view controller
+    var fromVC        = context.viewController(forKey: .from)!
+    let containerView = context.containerView
+    let toVC          = context.viewController(forKey: .to)!
+    
+    
+    if ( fromVC is UINavigationController) {
+        
+        let filter = fromVC.childViewControllers.filter{$0.isKind(of: ElongationViewController.self)}
+        fromVC = filter[0] as! ElongationViewController
+        
+    }else if (fromVC is UITabBarController ){
+        fromVC = (fromVC as! UITabBarController).selectedViewController as! ElongationViewController
+    }
+    
+    
+    
+    let sourceVC = fromVC as! ElongationViewController// ElongationViewController
+    let destinationVC = toVC as! ElongationDetailViewController// ElongationDetailViewController
+    
+    
+    let detailViewFinalFrame = context.finalFrame(for: destinationVC) // Final frame for presenting view controller
     
     guard
-      let rootTableView = root.tableView, // get `tableView` from root
-      let path = root.expandedIndexPath ?? rootTableView.indexPathForSelectedRow, // get expanded or selected indexPath
-      let cell = rootTableView.cellForRow(at: path) as? ElongationCell, // get expanded cell from root `tableView`
-      let view = detailView // unwrap optional `detailView`
-      else { return }
+        // get expanded or selected indexPath
+        let path = sourceVC.expandedIndexPath ?? sourceVC.tableView.indexPathForSelectedRow,
+        // get expanded cell from root `tableView`
+        let cell = sourceVC.tableView.cellForRow(at: path) as? ElongationCell
+        else { return }
     
     // Determine are `root` view is in expanded state.
     // We need to know that because animation depends on the state.
-    let isExpanded = root.state == .expanded
+    let isExpanded = sourceVC.state == .expanded
     
-
+    
     // Create `ElongationHeader` from `ElongationCell` and set it as `headerView` to `detail` view controller
     let header = cell.elongationHeader
-    detail.headerView = header
+    destinationVC.headerView = header
     
     // Get frame of expanded cell and convert it to `containerView` coordinates
-    let rect = rootTableView.rectForRow(at: path)
-    let cellFrame = rootTableView.convert(rect, to: containerView)
+    let rect = sourceVC.tableView.rectForRow(at: path)
+    let cellFrame = sourceVC.tableView.convert(rect, to: containerView)
     
     // Whole view snapshot
-    UIGraphicsBeginImageContextWithOptions(view.bounds.size, false, 0)
-    view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
+    UIGraphicsBeginImageContextWithOptions(toVC.view.bounds.size, false, 0)
+    toVC.view.drawHierarchy(in: toVC.view.bounds, afterScreenUpdates: true)
     let fullImage = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
     UIGraphicsEndImageContext()
+    
+    
     
     // Header snapshot
     UIGraphicsBeginImageContextWithOptions(header.frame.size, true, 0)
@@ -118,11 +121,12 @@ extension ElongationTransition {
     UIGraphicsEndImageContext()
     
     // TableView snapshot
-    let cellsSize = CGSize(width: view.frame.width, height: view.frame.height - header.frame.height)
+    let cellsSize = CGSize(width: toVC.view.frame.width, height: toVC.view.frame.height - header.frame.height)
     UIGraphicsBeginImageContextWithOptions(cellsSize, true, 0)
     fullImage.draw(at: CGPoint(x: 0, y: -header.frame.height))
     let tableSnapshot = UIGraphicsGetImageFromCurrentImageContext() ?? UIImage()
     UIGraphicsEndImageContext()
+    
     
     let headerSnapshotView = UIImageView(image: headerSnapsot)
     let tableViewSnapshotView = UIImageView(image: tableSnapshot)
@@ -131,44 +135,47 @@ extension ElongationTransition {
     tempView.backgroundColor = header.bottomView.backgroundColor
     
     // Add coming `view` to temporary `containerView`
-    containerView.addSubview(view)
+    containerView.addSubview(toVC.view)
     containerView.addSubview(tempView)
     containerView.addSubview(tableViewSnapshotView)
     
     // Update `bottomView`s top constraint and invalidate layout
-    header.bottomViewTopConstraint.constant = appearance.topViewHeight
+    header.bottomViewTopConstraint.constant = elongationConfig.topViewHeight
     header.bottomView.setNeedsLayout()
     
-    let height = isExpanded ? cellFrame.height : appearance.topViewHeight + appearance.bottomViewHeight
+    let height = isExpanded ? cellFrame.height : elongationConfig.topViewHeight + elongationConfig.bottomViewHeight
     
-    view.frame = CGRect(x: 0, y: cellFrame.minY, width: detailViewFinalFrame.width, height: cellFrame.height)
+    toVC.view.frame = CGRect(x: 0, y: cellFrame.minY, width: detailViewFinalFrame.width, height: cellFrame.height)
+    
     headerSnapshotView.frame = CGRect(x: 0, y: cellFrame.minY, width: cellFrame.width, height: height)
+    
     tableViewSnapshotView.frame = CGRect(x: 0, y: detailViewFinalFrame.maxY, width: cellsSize.width, height: cellsSize.height)
+    
     tempView.frame = CGRect(x: 0, y: cellFrame.maxY, width: detailViewFinalFrame.width, height: 0)
     
     // Animate to new state
-    UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: {
-      root.view?.alpha = 0
-      
-      header.scalableView.transform = .identity // reset scale to 1.0
-      header.contentView.frame = CGRect(x: 0, y: 0, width: cellFrame.width, height: cellFrame.height + self.appearance.bottomViewOffset)
-      
-      header.contentView.setNeedsLayout()
-      header.contentView.layoutIfNeeded()
-      
-      view.frame = detailViewFinalFrame
-      headerSnapshotView.frame = CGRect(x: 0, y: 0, width: cellFrame.width, height: height)
-      tableViewSnapshotView.frame = CGRect(x: 0, y: header.frame.height, width: detailViewFinalFrame.width, height: cellsSize.height)
-      tempView.frame = CGRect(x: 0, y: headerSnapshotView.frame.maxY, width: detailViewFinalFrame.width, height: detailViewFinalFrame.height)
+    UIView.animate(withDuration: animationDuration, delay: 0, options: .curveEaseInOut, animations: {
+        sourceVC.view?.alpha = 0
+        
+        header.scalableView.transform = .identity // reset scale to 1.0
+        header.contentView.frame = CGRect(x: 0, y: 0, width: cellFrame.width, height: cellFrame.height + self.elongationConfig.bottomViewOffset)
+        
+        header.contentView.setNeedsLayout()
+        header.contentView.layoutIfNeeded()
+        
+        toVC.view.frame = detailViewFinalFrame
+        headerSnapshotView.frame = CGRect(x: 0, y: 0, width: cellFrame.width, height: height)
+        tableViewSnapshotView.frame = CGRect(x: 0, y: header.frame.height, width: detailViewFinalFrame.width, height: cellsSize.height)
+        tempView.frame = CGRect(x: 0, y: headerSnapshotView.frame.maxY, width: detailViewFinalFrame.width, height: detailViewFinalFrame.height)
     }) { (completed) in
-      rootView?.removeFromSuperview()
-      tempView.removeFromSuperview()
-      headerSnapshotView.removeFromSuperview()
-      tableViewSnapshotView.removeFromSuperview()
-      context.completeTransition(completed)
+        //rootView?.removeFromSuperview()
+        tempView.removeFromSuperview()
+        headerSnapshotView.removeFromSuperview()
+        tableViewSnapshotView.removeFromSuperview()
+        context.completeTransition(completed)
     }
     
-  }
+    }
   
 }
 
@@ -176,24 +183,38 @@ extension ElongationTransition {
 extension ElongationTransition {
   
   fileprivate func dismiss(using context: UIViewControllerContextTransitioning) {
-    let root = self.root(from: context)
-    let detail = self.detail(from: context)
+    
+    let fromVC        = context.viewController(forKey: .from)!
     let containerView = context.containerView
-    let duration = transitionDuration(using: context)
+    var toVC          = context.viewController(forKey: .to)
+    
+    if ( toVC is UINavigationController) {
+        
+        let filter = toVC?.childViewControllers.filter{$0.isKind(of: ElongationViewController.self)}
+        toVC = filter?[0] as! ElongationViewController
+        
+    }else if (toVC is UITabBarController ){
+        toVC = (toVC as! UITabBarController).selectedViewController as! ElongationViewController
+    }
+    
+    
+    let sourceVC = fromVC as! ElongationDetailViewController// ElongationViewController
+    let destinationVC = toVC as! ElongationViewController// ElongationDetailViewController
+    
     
     guard
-      let header = detail.headerView,
-      let view = context.view(forKey: detailViewKey), // actual view of `detail` view controller
-      let rootTableView = root.tableView, // `tableView` of root view controller
-      let detailTableView = detail.tableView, // `tableView` of detail view controller
-      let path = root.expandedIndexPath ?? rootTableView.indexPathForSelectedRow, // `indexPath` of expanded or selected cell
-      let expandedCell = rootTableView.cellForRow(at: path) as? ElongationCell
-    else { return }
+        let header = sourceVC.headerView,
+        let view = fromVC.view, // actual view of `detail` view controller
+        let rootTableView = destinationVC.tableView, // `tableView` of root view controller
+        let detailTableView = sourceVC.tableView, // `tableView` of detail view controller
+        let path = destinationVC.expandedIndexPath ?? rootTableView.indexPathForSelectedRow, // `indexPath` of expanded or selected cell
+        let expandedCell = rootTableView.cellForRow(at: path) as? ElongationCell
+        else { return }
     
     // Collapse root view controller without animation
-    root.collapseCells(animated: false)
+    destinationVC.collapseCells(animated: false)
     expandedCell.topViewTopConstraint.constant = 0
-    expandedCell.topViewHeightConstraint.constant = appearance.topViewHeight
+    expandedCell.topViewHeightConstraint.constant = elongationConfig.topViewHeight
     expandedCell.hideSeparator(false, animated: true)
     expandedCell.topView.setNeedsLayout()
     
@@ -203,13 +224,13 @@ extension ElongationTransition {
     UIGraphicsEndImageContext()
     
     let yOffset = detailTableView.contentOffset.y
-    let topViewSize = CGSize(width: view.bounds.width, height: appearance.topViewHeight)
+    let topViewSize = CGSize(width: view.bounds.width, height: elongationConfig.topViewHeight)
     UIGraphicsBeginImageContextWithOptions(topViewSize, true, 0)
     header.topView.drawHierarchy(in: CGRect(origin: CGPoint.zero, size: topViewSize), afterScreenUpdates: true)
     let topViewImage = UIGraphicsGetImageFromCurrentImageContext()
     UIGraphicsEndImageContext()
     
-    let bottomViewSize = CGSize(width: view.bounds.width, height: appearance.bottomViewHeight)
+    let bottomViewSize = CGSize(width: view.bounds.width, height: elongationConfig.bottomViewHeight)
     UIGraphicsBeginImageContextWithOptions(bottomViewSize, true, 0)
     header.bottomView.drawHierarchy(in: CGRect(origin: CGPoint.zero, size: bottomViewSize), afterScreenUpdates: true)
     let bottomViewImage = UIGraphicsGetImageFromCurrentImageContext()
@@ -242,22 +263,22 @@ extension ElongationTransition {
     bottomViewImageView.frame = CGRect(x: 0, y: -yOffset + topViewSize.height, width: view.bounds.width, height: bottomViewSize.height)
     tableViewSnapshotView.frame = CGRect(x: 0, y: header.frame.maxY - yOffset, width: view.bounds.width, height: tableViewSnapshotView.frame.height)
     
-    UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: {
-      root.view?.alpha = 1
-      tableViewSnapshotView.alpha = 0
-      
-      // Animate views to collapsed cell size
-      let collapsedFrame = CGRect(x: 0, y: cellFrame.origin.y, width: header.frame.width, height: cellFrame.height)
-      topViewImageView.frame = collapsedFrame
-      bottomViewImageView.frame = collapsedFrame
-      tableViewSnapshotView.frame = collapsedFrame
-      expandedCell.contentView.layoutIfNeeded()
+    UIView.animate(withDuration: animationDuration, delay: 0, options: .curveEaseInOut, animations: {
+        destinationVC.view?.alpha = 1
+        tableViewSnapshotView.alpha = 0
+        
+        // Animate views to collapsed cell size
+        let collapsedFrame = CGRect(x: 0, y: cellFrame.origin.y, width: header.frame.width, height: cellFrame.height)
+        topViewImageView.frame = collapsedFrame
+        bottomViewImageView.frame = collapsedFrame
+        tableViewSnapshotView.frame = collapsedFrame
+        expandedCell.contentView.layoutIfNeeded()
     }, completion: { (completed) in
-      root.state = .normal
-      root.expandedIndexPath = nil
-      view.removeFromSuperview()
-      context.completeTransition(completed)
+        destinationVC.state = .normal
+        destinationVC.expandedIndexPath = nil
+        context.completeTransition(completed)
     })
+    
   }
   
 }

--- a/ElongationPreview/Source/ViewControllers/ElongationViewController.swift
+++ b/ElongationPreview/Source/ViewControllers/ElongationViewController.swift
@@ -22,6 +22,10 @@ fileprivate var interaction: UIPreviewInteraction!
 open class ElongationViewController: SwipableTableViewController {
   
   // MARK: Public properties
+   
+  
+  /// instance representing an object conforming to UIViewControllerAnimatedTransitioning, used to adjust how transition between two vc will behave
+  public var elongationTransition = ElongationTransition()
   
   /// `IndexPath` of expanded cell.
   public var expandedIndexPath: IndexPath?
@@ -396,17 +400,21 @@ extension ElongationViewController: UIPreviewInteractionDelegate {
   
 }
 
-// MARK: - Transition
+// MARK: - Transition  UIViewControllerTransitioningDelegate
 extension ElongationViewController: UIViewControllerTransitioningDelegate {
+
   
   /// This transition object will be used while dismissing `ElongationDetailViewController`.
   public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    return ElongationTransition(presenting: false)
+    
+    //elongationTransition.presenting = false
+    return elongationTransition
   }
   
   /// This transition object will be used while presenting `ElongationDetailViewController`.
   public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-    return ElongationTransition(presenting: true)
+    //elongationTransition.presenting = true
+    return elongationTransition
   }
   
 }

--- a/ElongationPreviewDemo/Base.lproj/Main.storyboard
+++ b/ElongationPreviewDemo/Base.lproj/Main.storyboard
@@ -1,48 +1,70 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="t1C-Dy-Tzl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5ZP-4m-Yfa">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
-        <scene sceneID="pWB-Td-sHf">
+        <!--NCStoryBoard-->
+        <scene sceneID="ghL-i1-Vlv">
             <objects>
-                <tableViewController id="t1C-Dy-Tzl" customClass="ViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="UaJ-kk-Hv5">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <connections>
-                            <outlet property="dataSource" destination="t1C-Dy-Tzl" id="5mq-gB-SnX"/>
-                            <outlet property="delegate" destination="t1C-Dy-Tzl" id="BMv-Zc-UBS"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="hfH-IK-dS7" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <viewControllerPlaceholder storyboardName="NCStoryBoard" id="haG-dG-ImO" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dNp-kp-RZu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="119" y="3"/>
+            <point key="canvasLocation" x="3233" y="-388"/>
         </scene>
-        <!--Detail View Controller-->
-        <scene sceneID="VTn-jn-qCC">
+        <!--Initial View Controller-->
+        <scene sceneID="vqd-lf-kzd">
             <objects>
-                <tableViewController storyboardIdentifier="DetailViewController" id="l2P-VE-cIq" customClass="DetailViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" id="WIC-mh-3FS">
+                <viewController id="5ZP-4m-Yfa" customClass="InitialViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Gjo-ow-SEC"/>
+                        <viewControllerLayoutGuide type="bottom" id="zlB-lK-agm"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="62r-Up-O6S">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                        <connections>
-                            <outlet property="dataSource" destination="l2P-VE-cIq" id="nKG-vo-QwY"/>
-                            <outlet property="delegate" destination="l2P-VE-cIq" id="2fx-Dx-HF7"/>
-                        </connections>
-                    </tableView>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="4RC-3D-Iwc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QIH-ty-XxS">
+                                <rect key="frame" x="72" y="190" width="230" height="61"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Embeded in Navigation Controller"/>
+                                <connections>
+                                    <action selector="NavigationControllerAction:" destination="5ZP-4m-Yfa" eventType="touchUpInside" id="kOH-az-muV"/>
+                                    <segue destination="haG-dG-ImO" kind="show" id="fh2-qd-b8J">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIY-8c-wqX">
+                                <rect key="frame" x="72" y="259" width="230" height="61"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Embeded in TabBar Controller"/>
+                                <connections>
+                                    <action selector="tabBarAction:" destination="5ZP-4m-Yfa" eventType="touchUpInside" id="Zmb-DZ-jr8"/>
+                                    <segue destination="jru-FV-y0w" kind="show" id="bo4-M3-KnG">
+                                        <nil key="action"/>
+                                    </segue>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6hH-oj-r3e" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="842" y="2"/>
+            <point key="canvasLocation" x="2532" y="-240"/>
+        </scene>
+        <!--TabBStoryBoard-->
+        <scene sceneID="R8L-Vi-Qr1">
+            <objects>
+                <viewControllerPlaceholder storyboardName="TabBStoryBoard" id="jru-FV-y0w" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FWJ-g9-pnm" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3244" y="-101"/>
         </scene>
     </scenes>
 </document>

--- a/ElongationPreviewDemo/InitialViewController.swift
+++ b/ElongationPreviewDemo/InitialViewController.swift
@@ -1,0 +1,27 @@
+//
+//  InitialViewController.swift
+//  ElongationPreview
+//
+//  Created by boris on 23/8/17.
+//  Copyright © 2017 Ramotion. All rights reserved.
+//
+
+import UIKit
+class InitialViewController: UIViewController {
+    
+    
+    let userDefaults = UserDefaults.standard
+    
+    @IBAction func NavigationControllerAction(_ sender: Any) {
+        userDefaults.set("NCStoryBoard", forKey: "storyboard_name")
+    }
+    
+
+    
+    @IBAction func tabBarAction(_ sender: Any) {
+            userDefaults.set("TabBStoryBoard", forKey: "storyboard_name")
+    }
+    
+    
+    
+}

--- a/ElongationPreviewDemo/NCStoryBoard.storyboard
+++ b/ElongationPreviewDemo/NCStoryBoard.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="1tR-Ov-T0M">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Title-->
+        <scene sceneID="Qx2-3g-p89">
+            <objects>
+                <tableViewController providesPresentationContextTransitionStyle="YES" id="uWg-kY-ngZ" customClass="ViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="vvt-fb-tPf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <connections>
+                            <outlet property="dataSource" destination="uWg-kY-ngZ" id="lIN-tz-T3f"/>
+                            <outlet property="delegate" destination="uWg-kY-ngZ" id="uEh-C5-kK4"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Title" id="Jar-rP-n5F"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="kxL-V7-ns0" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3710" y="-126"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="D4S-k6-0zV">
+            <objects>
+                <tableViewController storyboardIdentifier="DetailViewController" id="rJF-uD-DAD" customClass="DetailViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" id="QBb-nS-oNv">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <connections>
+                            <outlet property="dataSource" destination="rJF-uD-DAD" id="g12-Ci-QcM"/>
+                            <outlet property="delegate" destination="rJF-uD-DAD" id="9t4-Uy-ojD"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="j0h-yO-qfa" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4438" y="-126"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="wBA-MX-MW9">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="1tR-Ov-T0M" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="LgT-tS-B2Q">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="uWg-kY-ngZ" kind="relationship" relationship="rootViewController" id="YsL-wS-Acb"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ukp-xA-E2c" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2769" y="-126"/>
+        </scene>
+    </scenes>
+</document>

--- a/ElongationPreviewDemo/TabBStoryBoard.storyboard
+++ b/ElongationPreviewDemo/TabBStoryBoard.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="e0r-oY-Diz">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Item-->
+        <scene sceneID="LSG-ez-tGj">
+            <objects>
+                <tableViewController providesPresentationContextTransitionStyle="YES" id="MDC-zm-zmp" customClass="ViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="SFm-Et-Okd">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <connections>
+                            <outlet property="dataSource" destination="MDC-zm-zmp" id="Rw8-b1-k9o"/>
+                            <outlet property="delegate" destination="MDC-zm-zmp" id="6zG-f4-4Ke"/>
+                        </connections>
+                    </tableView>
+                    <tabBarItem key="tabBarItem" title="Item" id="NzN-Lt-lsZ"/>
+                    <navigationItem key="navigationItem" id="ZHF-mD-xki"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xUa-UN-aog" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3575" y="-521"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="KkM-LL-wNn">
+            <objects>
+                <tableViewController storyboardIdentifier="DetailViewController" id="syr-k5-s7H" customClass="DetailViewController" customModule="ElongationPreviewDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="1" sectionFooterHeight="1" id="CMh-1G-sFB">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <connections>
+                            <outlet property="dataSource" destination="syr-k5-s7H" id="pEc-Pv-lpp"/>
+                            <outlet property="delegate" destination="syr-k5-s7H" id="MT8-Sy-VXQ"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="M7B-5Z-FGT" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4298" y="-522"/>
+        </scene>
+        <!--Tab Bar Controller-->
+        <scene sceneID="qzQ-dm-vki">
+            <objects>
+                <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="e0r-oY-Diz" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <tabBar key="tabBar" contentMode="scaleToFill" id="BDl-Ve-DSc">
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    </tabBar>
+                    <connections>
+                        <segue destination="MDC-zm-zmp" kind="relationship" relationship="viewControllers" id="R6r-V7-tLZ"/>
+                    </connections>
+                </tabBarController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x50-xR-m8h" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2638" y="-521"/>
+        </scene>
+    </scenes>
+</document>

--- a/ElongationPreviewDemo/ViewController.swift
+++ b/ElongationPreviewDemo/ViewController.swift
@@ -26,7 +26,12 @@ class ViewController: ElongationViewController {
   
   override func openDetailView(for indexPath: IndexPath) {
     let id = String(describing: DetailViewController.self)
-    guard let detailViewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: id) as? DetailViewController else { return }
+    
+    //retrieve the storyboard_name key stored while touchUpInside event on InitialViewController
+    let storyboardName = UserDefaults.standard.object(forKey: "storyboard_name") as! String
+    
+    //load appropiate storyboard
+    guard let detailViewController = UIStoryboard(name: storyboardName, bundle: nil).instantiateViewController(withIdentifier: id) as? DetailViewController else { return }
     let villa = datasource[indexPath.row]
     detailViewController.title = villa.title
     expand(viewController: detailViewController)


### PR DESCRIPTION
This will add capability to this excellent component to support automatically without user intervention when the UITableView is embedded into main Navigation flows (UINavigationController and TabBarController).

The InitialViewController class is Just a Demo to demonstrate how can be launched from this to different approach. There are StoryBoard references to navigate to either types of navigation layouts. 

I've keep your animation logic in the animation transition coordinator, just remove some unnecessary code for this approach. 

Hope this help make this component more powerful.
thanks.